### PR TITLE
fix bugs

### DIFF
--- a/.changeset/fair-cups-jam.md
+++ b/.changeset/fair-cups-jam.md
@@ -1,9 +1,13 @@
 ---
+"@tlog/shared": patch
+"@tlog/cli": patch
 "vscode-tlog": patch
 "@tlog/mcp": patch
 ---
 
-Release fixes for VS Code extension owner persistence and MCP runtime compatibility.
+Release fixes for owner persistence and MCP runtime compatibility across shared packages.
 
+- `@tlog/shared`: include schema/domain updates required by the owner persistence and MCP compatibility fixes.
+- `@tlog/cli`: align CLI behavior with the latest shared schema/runtime updates in this release.
 - `vscode-tlog`: fix unreliable persistence of `owners` values when editing test data (suite-level owners, case-level owners, and issue-level owners).
 - `@tlog/mcp`: fix runtime failure after global install (`npm install -g @tlog/mcp`) where MCP clients can list prompts/resources but fail on `listTools` with `Cannot read properties of undefined (reading '_zod')`.

--- a/.changeset/fair-cups-jam.md
+++ b/.changeset/fair-cups-jam.md
@@ -1,0 +1,9 @@
+---
+"vscode-tlog": patch
+"@tlog/mcp": patch
+---
+
+Release fixes for VS Code extension owner persistence and MCP runtime compatibility.
+
+- `vscode-tlog`: fix unreliable persistence of `owners` values when editing test data (suite-level owners, case-level owners, and issue-level owners).
+- `@tlog/mcp`: fix runtime failure after global install (`npm install -g @tlog/mcp`) where MCP clients can list prompts/resources but fail on `listTools` with `Cannot read properties of undefined (reading '_zod')`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -212,8 +212,8 @@ tlog list templates --dir templates --format text
 
 ### Case commands
 
-- `tlog case create --suite-dir <dir> --id <id> --title <title> [--status <todo|doing|done|null>] [--tags <a,b>]`
-- `tlog case update --id <id> [--dir <dir>] [--status <todo|doing|done|null>] [--tags <a,b>] [--description <text>] [--operations <a,b>] [--related <a,b>] [--remarks <a,b>] [--scoped <true|false>] [--completed-day <YYYY-MM-DD|null>] [--tests-file <path>] [--issues-file <path>]`
+- `tlog case create --suite-dir <dir> --id <id> --title <title> [--owners <a,b>] [--status <todo|doing|done|null>] [--tags <a,b>]`
+- `tlog case update --id <id> [--dir <dir>] [--owners <a,b>] [--status <todo|doing|done|null>] [--tags <a,b>] [--description <text>] [--operations <a,b>] [--related <a,b>] [--remarks <a,b>] [--scoped <true|false>] [--completed-day <YYYY-MM-DD|null>] [--tests-file <path>] [--issues-file <path>]`
 - `tlog case delete --id <id> [--dir <dir>] [--yes]`
 - `tlog case list [--dir <dir>] [--id <pattern>] [--tag <tag>] [--owners <a,b>] [--scoped-only] [--issue-has <keyword>] [--issue-status <open|doing|resolved|pending>] [--status <todo|doing|done|null>] [--format <text|json|csv>] [--output <path>]`
 

--- a/packages/cli/src/commands/suite-case.ts
+++ b/packages/cli/src/commands/suite-case.ts
@@ -32,6 +32,7 @@ export interface CaseCreateOptions {
   suiteDir: string;
   id: string;
   title: string;
+  owners?: string;
   status?: string;
   tags?: string;
 }
@@ -118,6 +119,7 @@ export function runCaseCreate(cwd: string, options: CaseCreateOptions, globalOpt
   const testCase = buildDefaultCase({
     id: options.id,
     title: options.title,
+    owners: splitCsv(options.owners),
     status: status === null ? undefined : status,
     tags: splitCsv(options.tags)
   });

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -43,6 +43,7 @@ export interface SuiteUpdateOptions {
 export interface CaseUpdateOptions {
   dir: string;
   id: string;
+  owners?: string;
   status?: string;
   tags?: string;
   description?: string;
@@ -193,6 +194,7 @@ export function runCaseUpdate(cwd: string, options: CaseUpdateOptions, globalOpt
   const updated: TestCase = {
     ...current,
     ...(options.description !== undefined ? { description: options.description } : {}),
+    ...(options.owners !== undefined ? { owners: splitCsv(options.owners) } : {}),
     ...(options.tags !== undefined ? { tags: splitCsv(options.tags) } : {}),
     ...(options.operations !== undefined ? { operations: splitCsv(options.operations) } : {}),
     ...(options.related !== undefined ? { related: splitCsv(options.related) } : {}),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -127,6 +127,7 @@ function createProgram(): Command {
     .requiredOption("--suite-dir <dir>", "target suite directory")
     .requiredOption("--id <caseId>", "case id")
     .requiredOption("--title <caseTitle>", "case title")
+    .option("--owners <a,b,c>", "owners list")
     .option("--status <todo|doing|done|null>", "case status")
     .option("--tags <a,b,c>", "tags list")
     .action((options: CaseCreateOptions, command: Command) => {
@@ -138,6 +139,7 @@ function createProgram(): Command {
     .description("Update case YAML by id")
     .requiredOption("--id <caseId>", "case id")
     .option("--dir <dir>", "search root directory", "tests")
+    .option("--owners <a,b,c>", "case owners")
     .option("--status <todo|doing|done|null>", "case status")
     .option("--tags <a,b,c>", "case tags")
     .option("--description <text>", "case description")

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -145,6 +145,8 @@ describe("tlog cli", () => {
       "case-1",
       "--title",
       "Login Success",
+      "--owners",
+      "qa-team",
       "--status",
       "doing"
     ]);
@@ -152,6 +154,7 @@ describe("tlog cli", () => {
     expect(result.exitCode).toBe(0);
     const file = readFileSync(join(suiteDir, "case-1.testcase.yaml"), "utf8");
     expect(file).toContain("id: case-1");
+    expect(file).toContain("- qa-team");
     expect(file).toContain("status: doing");
   });
 
@@ -218,12 +221,19 @@ describe("tlog cli", () => {
       "tests",
       "--id",
       "case-a",
+      "--owners",
+      "qa,ops",
       "--issues-file",
       issuesFile,
       "--json"
     ]);
     expect(result.exitCode).toBe(0);
     const caseRaw = readFileSync(join(suiteDir, "case-a.testcase.yaml"), "utf8");
+    expect(caseRaw).toContain("owners:");
+    expect(caseRaw).toContain("- qa");
+    expect(caseRaw).toContain("- ops");
+    expect(caseRaw).toContain("incident: incident-a");
+    expect(caseRaw).toContain("    owners:");
     expect(caseRaw).toContain("detectedDay: 2026-02-20");
     expect(caseRaw).toContain("completedDay: null");
   });

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -147,10 +147,11 @@ A robust workflow (inspired by production-grade MCP servers):
 
 1. `get_tlog_schema` (topic: `all` or specific).
 2. `get_tlog_schema_examples` for concrete payload patterns.
-3. `collect_missing_context` before mutation.
-4. Mutation tools with `write=false` first.
-5. Apply with `write=true`.
-6. `validate_tests_directory` to verify final consistency.
+3. `preflight_tool_input` before mutation (strict schema check).
+4. `collect_missing_context` before mutation (context completeness check).
+5. Mutation tools with `write=false` first.
+6. Apply with `write=true`.
+7. `validate_tests_directory` to verify final consistency.
 
 ## Feature Overview
 
@@ -174,6 +175,7 @@ Tools:
 
 - `get_tlog_schema`
 - `get_tlog_schema_examples`
+- `preflight_tool_input`
 - `collect_missing_context`
 
 ## 2) Authoring and Mutation
@@ -227,6 +229,7 @@ For quick scanning, here is the complete tool set currently registered by this s
 
 - `get_tlog_schema`
 - `get_tlog_schema_examples`
+- `preflight_tool_input`
 - `collect_missing_context`
 - `create_suite_from_prompt`
 - `create_testcase_from_prompt`

--- a/packages/mcp/src/schema-contract.ts
+++ b/packages/mcp/src/schema-contract.ts
@@ -468,9 +468,10 @@ export function getSchemaUsageTemplate(useCase: "create_suite" | "create_case" |
     "Step 1: Call get_tlog_schema(topic) and get_tlog_schema_examples(topic).",
     "Step 2: Build input using only schema-defined fields.",
     "Step 3: Use enum values exactly as declared (case-sensitive).",
-    "Step 4: Call collect_missing_context(operation, draft) before mutation calls.",
-    "Step 5: If missingFields is non-empty, ask user questions and retry.",
-    "Step 6: Run mutation tool with write=false first, then write=true after review."
+    "Step 4: Call preflight_tool_input(operation, draft) before mutation calls.",
+    "Step 5: Call collect_missing_context(operation, draft) for context-heavy operations.",
+    "Step 6: If missingFields or preflight errors are non-empty, ask user questions and retry.",
+    "Step 7: Run mutation tool with write=false first, then write=true after review."
   ];
 
   if (useCase === "create_suite") {

--- a/packages/mcp/src/schemas.ts
+++ b/packages/mcp/src/schemas.ts
@@ -1,126 +1,164 @@
 import { z } from "zod";
+import {
+  issueStatusSchema,
+  suiteSchema,
+  testCaseSchema,
+  testcaseStatusSchema,
+  testResultStatusSchema
+} from "@tlog/shared";
+
+const nonEmptyStringSchema = z.string().min(1);
+const stringArraySchema = z.array(z.string().min(1));
+
+const suiteFieldsSchema = suiteSchema.omit({ id: true, title: true }).partial().strict();
+const caseFieldsSchema = testCaseSchema.omit({ id: true, title: true }).partial().strict();
+
+const suitePatchSchema = suiteSchema.omit({ id: true }).partial().strict();
+const casePatchSchema = testCaseSchema.omit({ id: true }).partial().strict();
+
+const caseContextTestSchema = z
+  .object({
+    name: nonEmptyStringSchema.optional(),
+    expected: nonEmptyStringSchema,
+    actual: z.string().optional(),
+    trails: stringArraySchema.optional(),
+    status: testResultStatusSchema.nullable().optional()
+  })
+  .strict();
+
+const caseContextSchema = z
+  .object({
+    operations: stringArraySchema.optional(),
+    tests: z.array(caseContextTestSchema).optional(),
+    expected: z.union([nonEmptyStringSchema, stringArraySchema]).optional(),
+    tags: stringArraySchema.optional(),
+    description: z.string().optional()
+  })
+  .strict();
 
 export const createSuiteInputSchema = {
-  workspaceRoot: z.string().min(1),
-  targetDir: z.string().min(1),
-  instruction: z.string().min(1),
-  defaults: z.record(z.unknown()).optional(),
+  workspaceRoot: nonEmptyStringSchema,
+  targetDir: nonEmptyStringSchema,
+  instruction: nonEmptyStringSchema,
+  defaults: suiteFieldsSchema.optional(),
   write: z.boolean().default(false)
 };
 
 export const createCaseInputSchema = {
-  workspaceRoot: z.string().min(1),
-  suiteDir: z.string().min(1),
-  instruction: z.string().min(1),
-  context: z.record(z.unknown()).optional(),
+  workspaceRoot: nonEmptyStringSchema,
+  suiteDir: nonEmptyStringSchema,
+  instruction: nonEmptyStringSchema,
+  context: caseContextSchema.optional(),
   write: z.boolean().default(false)
 };
 
 export const expandCaseInputSchema = {
-  workspaceRoot: z.string().min(1),
-  testcasePath: z.string().min(1),
-  instruction: z.string().min(1),
-  preserveFields: z.array(z.string()).default([]),
+  workspaceRoot: nonEmptyStringSchema,
+  testcasePath: nonEmptyStringSchema,
+  instruction: nonEmptyStringSchema,
+  preserveFields: stringArraySchema.default([]),
   write: z.boolean().default(false)
 };
 
 export const organizeInputSchema = {
-  workspaceRoot: z.string().min(1),
-  testcasePath: z.string().optional(),
-  testcase: z.record(z.unknown()).optional(),
+  workspaceRoot: nonEmptyStringSchema,
+  testcasePath: nonEmptyStringSchema.optional(),
+  testcase: casePatchSchema.optional(),
   strategy: z.enum(["risk-based", "flow-based", "component-based"]).default("flow-based"),
   mode: z.enum(["replace", "append", "auto"]).default("auto"),
   write: z.boolean().default(false)
 };
 
 export const initTestsDirectoryInputSchema = {
-  workspaceRoot: z.string().min(1),
-  outputDir: z.string().optional(),
-  templateDir: z.string().nullable().optional(),
+  workspaceRoot: nonEmptyStringSchema,
+  outputDir: nonEmptyStringSchema.optional(),
+  templateDir: nonEmptyStringSchema.nullable().optional(),
   write: z.boolean().default(false)
 };
 
 export const createTemplateDirectoryInputSchema = {
-  workspaceRoot: z.string().min(1),
-  outputDir: z.string().min(1),
-  fromDir: z.string().nullable().optional(),
+  workspaceRoot: nonEmptyStringSchema,
+  outputDir: nonEmptyStringSchema,
+  fromDir: nonEmptyStringSchema.nullable().optional(),
   write: z.boolean().default(false)
 };
 
 export const createSuiteFileInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
-  id: z.string().min(1),
-  title: z.string().min(1),
-  fields: z.record(z.unknown()).optional(),
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
+  id: nonEmptyStringSchema,
+  title: nonEmptyStringSchema,
+  fields: suiteFieldsSchema.optional(),
   write: z.boolean().default(false)
 };
 
 export const createCaseFileInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
-  id: z.string().min(1),
-  title: z.string().min(1),
-  fields: z.record(z.unknown()).optional(),
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
+  id: nonEmptyStringSchema,
+  title: nonEmptyStringSchema,
+  fields: caseFieldsSchema.optional(),
   write: z.boolean().default(false)
 };
 
 export const validateTestsDirectoryInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1)
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema
 };
 
 export const listTemplatesInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1)
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema
 };
 
 export const listSuitesInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
   filters: z
     .object({
       id: z.string().optional(),
       tag: z.string().optional()
     })
+    .strict()
     .optional()
 };
 
 export const listCasesInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
   filters: z
     .object({
       id: z.string().optional(),
-      status: z.string().optional(),
+      status: testcaseStatusSchema.optional(),
       tags: z.array(z.string()).optional(),
       owners: z.array(z.string()).optional(),
       scopedOnly: z.boolean().optional(),
       issueHas: z.string().optional(),
-      issueStatus: z.string().optional()
+      issueStatus: issueStatusSchema.optional()
     })
+    .strict()
     .optional()
 };
 
 export const resolveEntityPathByIdInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
-  id: z.string().min(1)
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
+  id: nonEmptyStringSchema
 };
 
 export const updateSuiteInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
-  id: z.string().min(1),
-  patch: z.record(z.unknown()),
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
+  id: nonEmptyStringSchema,
+  patch: suitePatchSchema,
   write: z.boolean().default(false)
 };
 
 export const updateCaseInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
-  id: z.string().min(1),
-  patch: z.record(z.unknown()),
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
+  id: nonEmptyStringSchema,
+  patch: casePatchSchema,
   write: z.boolean().default(false)
 };
 
@@ -139,38 +177,87 @@ export const collectMissingContextInputSchema = {
 };
 
 export const resolveRelatedTargetsInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
-  sourceId: z.string().min(1),
-  relatedIds: z.array(z.string().min(1)).optional()
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
+  sourceId: nonEmptyStringSchema,
+  relatedIds: stringArraySchema.optional()
 };
 
 export const syncRelatedInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
-  sourceId: z.string().min(1),
-  relatedIds: z.array(z.string().min(1)).optional(),
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
+  sourceId: nonEmptyStringSchema,
+  relatedIds: stringArraySchema.optional(),
   mode: z.enum(["one-way", "two-way"]).default("two-way"),
   write: z.boolean().default(false)
 };
 
 export const getWorkspaceSnapshotInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
   excludeUnscoped: z.boolean().default(false)
 };
 
 export const suiteStatsInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
-  suiteId: z.string().min(1),
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
+  suiteId: nonEmptyStringSchema,
   excludeUnscoped: z.boolean().default(false)
 };
 
 export const deleteEntityInputSchema = {
-  workspaceRoot: z.string().min(1),
-  dir: z.string().min(1),
-  id: z.string().min(1),
+  workspaceRoot: nonEmptyStringSchema,
+  dir: nonEmptyStringSchema,
+  id: nonEmptyStringSchema,
   dryRun: z.boolean(),
   confirm: z.boolean().optional()
 };
+
+export const mutationOperationSchema = z.enum([
+  "create_suite_from_prompt",
+  "create_testcase_from_prompt",
+  "create_suite_file",
+  "create_case_file",
+  "update_suite",
+  "update_case"
+]);
+
+export const preflightToolInputSchema = {
+  operation: mutationOperationSchema,
+  draft: z.record(z.unknown())
+};
+
+const mutationInputShapeMap = {
+  create_suite_from_prompt: createSuiteInputSchema,
+  create_testcase_from_prompt: createCaseInputSchema,
+  create_suite_file: createSuiteFileInputSchema,
+  create_case_file: createCaseFileInputSchema,
+  update_suite: updateSuiteInputSchema,
+  update_case: updateCaseInputSchema
+} as const;
+
+export type MutationOperation = z.infer<typeof mutationOperationSchema>;
+
+export function validateMutationDraft(operation: MutationOperation, draft: Record<string, unknown>): {
+  valid: boolean;
+  errors: Array<{ path: string; message: string }>;
+  normalizedDraft?: Record<string, unknown>;
+} {
+  const schema = z.object(mutationInputShapeMap[operation]).strict();
+  const parsed = schema.safeParse(draft);
+  if (parsed.success) {
+    return {
+      valid: true,
+      errors: [],
+      normalizedDraft: parsed.data
+    };
+  }
+
+  return {
+    valid: false,
+    errors: parsed.error.issues.map((issue) => ({
+      path: issue.path.length > 0 ? issue.path.join(".") : "(root)",
+      message: issue.message
+    }))
+  };
+}

--- a/packages/shared/src/builders.ts
+++ b/packages/shared/src/builders.ts
@@ -17,6 +17,7 @@ export interface BuildDefaultCaseInput {
   id: string;
   title: string;
   description?: string;
+  owners?: string[];
   scoped?: boolean;
   status?: TestCaseStatus;
   tags?: string[];
@@ -66,6 +67,7 @@ export function buildDefaultCase(input: BuildDefaultCaseInput): TestCase {
   const candidate: TestCase = {
     id: input.id,
     title: input.title,
+    owners: input.owners ?? [],
     tags: input.tags ?? [],
     description: input.description ?? "",
     scoped: input.scoped ?? true,

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -54,6 +54,7 @@ export interface Issue {
 export interface TestCase {
   id: string;
   title: string;
+  owners: string[];
   tags: string[];
   description: string;
   scoped: boolean;

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -32,7 +32,7 @@ export const suiteSchema = z
     tags: stringArraySchema,
     description: z.string(),
     scoped: z.boolean(),
-    owners: stringArraySchema,
+    owners: stringArraySchema.default([]),
     duration: durationSchema,
     related: stringArraySchema,
     remarks: stringArraySchema
@@ -69,7 +69,7 @@ export const issueSchema = z
   }, z
     .object({
       incident: nonEmptyStringSchema,
-      owners: stringArraySchema,
+      owners: stringArraySchema.default([]),
       causes: stringArraySchema,
       solutions: stringArraySchema,
       status: issueStatusSchema,
@@ -84,6 +84,7 @@ export const testCaseSchema = z
   .object({
     id: nonEmptyStringSchema,
     title: nonEmptyStringSchema,
+    owners: stringArraySchema.default([]),
     tags: stringArraySchema,
     description: z.string(),
     scoped: z.boolean(),

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -69,6 +69,7 @@ function buildSuiteWarnings(suite: Suite): ValidationDiagnostic[] {
 function buildCaseWarnings(testCase: TestCase): ValidationDiagnostic[] {
   const warnings: ValidationDiagnostic[] = [];
 
+  pushArrayWarnings(warnings, testCase.owners, "owners", "owners is empty");
   pushArrayWarnings(warnings, testCase.tags, "tags", "tags is empty");
   pushArrayWarnings(warnings, testCase.operations, "operations", "operations is empty");
   pushArrayWarnings(warnings, testCase.tests, "tests", "tests is empty");

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -68,6 +68,7 @@ type ManagerMessage =
       title: string;
       description: string;
       tags: string;
+      owners: string;
       scoped: boolean;
       status: "todo" | "doing" | "done" | null;
       operations: string[];
@@ -372,6 +373,7 @@ async function openManager(
               title: message.title,
               description: message.description,
               tags: splitCsv(message.tags),
+              owners: splitCsv(message.owners),
               scoped: message.scoped,
               status: message.status,
               operations: message.operations,
@@ -382,6 +384,7 @@ async function openManager(
               tests: message.tests,
               issues: message.issues.map((issue) => ({
                 ...issue,
+                owners: Array.isArray(issue.owners) ? issue.owners : [],
                 related: normalizeRelatedRefs(issue.related ?? [], relatedOptions),
                 remarks: issue.remarks ?? []
               }))

--- a/packages/vscode-extension/src/tlog-workspace.ts
+++ b/packages/vscode-extension/src/tlog-workspace.ts
@@ -47,6 +47,7 @@ export interface CaseCard {
   scoped: boolean;
   status: TestCase["status"];
   description: string;
+  owners: string[];
   tags: string[];
   suiteId?: string;
   suiteOwners: string[];
@@ -205,7 +206,18 @@ export async function updateCase(
   path: string,
   patch: Pick<
     TestCase,
-    "title" | "description" | "tags" | "scoped" | "status" | "operations" | "related" | "remarks" | "completedDay" | "tests" | "issues"
+    | "title"
+    | "description"
+    | "owners"
+    | "tags"
+    | "scoped"
+    | "status"
+    | "operations"
+    | "related"
+    | "remarks"
+    | "completedDay"
+    | "tests"
+    | "issues"
   >
 ): Promise<void> {
   const current = await readYamlFile<TestCase>(path);
@@ -213,6 +225,7 @@ export async function updateCase(
     ...current,
     title: patch.title,
     description: patch.description,
+    owners: patch.owners,
     tags: patch.tags,
     scoped: patch.scoped,
     status: patch.status,
@@ -353,6 +366,7 @@ export async function getWorkspaceSnapshot(rootDir: string, filters: SearchFilte
         scoped: testCase.scoped,
         status: testCase.status,
         description: testCase.description,
+        owners: testCase.owners,
         tags: testCase.tags,
         suiteId: nodes.find((candidate) => candidate.type === "suite" && candidate.path === node.parentPath)?.id
         ,
@@ -378,6 +392,7 @@ function casesToTestCase(cases: CaseCard[]): TestCase[] {
   return cases.map((item) => ({
     id: item.id,
     title: item.title,
+    owners: item.owners,
     tags: item.tags,
     description: item.description,
     scoped: item.scoped,

--- a/packages/vscode-extension/src/webviews.ts
+++ b/packages/vscode-extension/src/webviews.ts
@@ -1162,7 +1162,7 @@ export function managerHtml(): string {
           '<div class="field"><label>issues</label><div><div data-role="issuesList"></div><button data-role="addIssue" class="secondary" type="button" style="margin-top:6px;">Add Issue</button></div></div>' +
           '';
         const ops = createNumberedList(card.querySelector('[data-role="operationsList"]'), testCase.operations || []);
-        createChipEditor(card.querySelector('[data-role="ownersEditor"]'), testCase.suiteOwners || []);
+        const ownersEditor = createChipEditor(card.querySelector('[data-role="ownersEditor"]'), testCase.owners || []);
         const tagsEditor = createChipEditor(card.querySelector('[data-role="tagsEditor"]'), testCase.tags || []);
         card.querySelector('[data-role="addOp"]').addEventListener('click', () => ops.add(''));
         const testsEditor = createTestsEditor(card, testCase.tests || []);
@@ -1184,6 +1184,7 @@ export function managerHtml(): string {
             title: card.querySelector('[data-role="title"]').value,
             description: card.querySelector('[data-role="description"]').value,
             tags: tagsEditor.getValues().join(','),
+            owners: ownersEditor.getValues().join(','),
             scoped: card.querySelector('[data-role="scoped"]').checked,
             status: card.querySelector('[data-role="status"]').value || null,
             operations: ops.values(),


### PR DESCRIPTION
## Summary

Describe what this PR changes and why.

## Related Issue

- Closes #20 #21 

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only

## Scope

Affected package(s):

- [x] `packages/cli`
- [x] `packages/mcp`
- [x] `packages/vscode-extension`
- [x] `packages/shared`
- [ ] Other

## What Changed

- `@tlog/shared`: include schema/domain updates required by the owner persistence and MCP compatibility fixes.
- `@tlog/cli`: align CLI behavior with the latest shared schema/runtime updates in this release.
- `vscode-tlog`: fix unreliable persistence of `owners` values when editing test data (suite-level owners, case-level owners, and issue-level owners).
- `@tlog/mcp`: fix runtime failure after global install (`npm install -g @tlog/mcp`) where MCP clients can list prompts/resources but fail on `listTools` with `Cannot read properties of undefined (reading '_zod')`.

## Validation

Commands run locally:

```bash
npm run typecheck
npm run test
```

Additional commands (if applicable):

```bash
# e.g.
# npm run --workspace @tlog/cli test
# npm run --workspace @tlog/mcp test
```

## Backward Compatibility

- [x] No breaking change
- [x] Breaking change (describe below)

If breaking, explain migration impact:

## Checklist

- [x] I updated related docs/README where needed.
- [x] I added or updated tests where needed.
- [x] I verified no unrelated files were modified intentionally.
- [x] I used the issue/PR templates and linked related issue(s).
